### PR TITLE
Added fix for postprocessing CSR

### DIFF
--- a/src/appier/base.py
+++ b/src/appier/base.py
@@ -179,7 +179,7 @@ ALLOW_METHODS = "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS"
 """ The default value to be used in the "Access-Control-Allow-Methods"
 header value, this should not be too restrictive """
 
-CONTENT_SECURITY = "default-src * ws://* wss://* data: blob:; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';"
+CONTENT_SECURITY = "default-src * ws://* wss://* data: blob:; script-src blob: * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';"
 """ The default value to be used in the "Content-Security-Policy"
 header value, this should not be too restrictive """
 


### PR DESCRIPTION
Newer features for client-side-rendering require the loading of "blob:" scripts for anti-aliasing purposes, this prevents browser from blocking the necessary requests.