### PR TITLE
Add AMQPExchange and support AMQPQueue binding to an exchange

### DIFF
--- a/src/appier/__init__.py
+++ b/src/appier/__init__.py
@@ -118,7 +118,7 @@ from .mongo import Mongo, MongoAsync, MongoEncoder, get_connection, get_connecti
 from .observer import Observable
 from .part import Part
 from .preferences import Preferences, MemoryPreferences, FilePreferences, RedisPreferences
-from .queuing import Queue, MemoryQueue, MultiprocessQueue, AMQPQueue
+from .queuing import Queue, MemoryQueue, MultiprocessQueue, AMQPQueue, AMQPExchange
 from .redisdb import Redis
 from .request import CODE_STRINGS, Request, MockRequest
 from .scheduler import Scheduler


### PR DESCRIPTION
Issue: https://github.com/ripe-tech/ripe-compose/issues/68

This PR:
- adds an `AMQPExchange` class that abstracts a connection to a RabbitMQ exchange
- an exchange belongs to a cluster, not a single node; hence, this class accepts a list of broker URLs; if the connection to one fails, it attempts to connect to the rest; if all brokers fail, this class will attempt to reconnect forever (but such a catastrophic failure will likely require a cluster reset regardless)
- changes `AMQPQueue` class to accept an optional exchange name and routing key; if present, it binds the queue to that exchange using that routing key