### PR TITLE
Removed dot from route replace regex

### DIFF
--- a/src/appier/base.py
+++ b/src/appier/base.py
@@ -657,7 +657,7 @@ class App(
         expression = "^" + expression + "$"
         expression = INT_REGEX.sub(r"(?P[\1>[\\d]+)", expression)
         expression = REGEX_REGEX.sub(r"(?P[\2>\1)", expression)
-        expression = REPLACE_REGEX.sub(r"(?P[\4>[\\@\\+\\:\\.\\s\\w-]+)", expression)
+        expression = REPLACE_REGEX.sub(r"(?P[\4>[\\@\\+\\:\\s\\w-]+)", expression)
         expression = expression.replace("?P[", "?P<")
         return [method, re.compile(expression, re.UNICODE), function, context, opts] #@UndefinedVariable
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | There was a problem in the route parsing and regex replacement. For example, with the following route endpoints `/api/builds/<str:name>/fonts/<str:font>.<str:format>` the font and format are wrongly extracted, where the parameter `SRGunmetal-Regular.fnt` results in `font: SRGunmetal-Regular.f` and `format: t`. |
| Dependencies | -- |
| Decisions | Removed the `.` from the `REPLACE_REGEX`. All other routes with dots are working as supposed and the route mentiond above as well. |
| Animated GIF | -- |