### PR TITLE
feat: apply orientation exif info on image after resize

### DIFF
--- a/src/appier/typesf.py
+++ b/src/appier/typesf.py
@@ -40,6 +40,7 @@ __license__ = "Apache License, Version 2.0"
 import uuid
 import base64
 import hashlib
+import PIL.ImageOps
 
 from . import util
 from . import crypt
@@ -513,6 +514,7 @@ def image(width = None, height = None, format = "png", **kwargs):
                 image = PIL.Image.open(in_buffer)
                 image = self._resize(image, size)
                 image = self._format(image, format, background)
+                image = PIL.ImageOps.exif_transpose(image)
                 image.save(out_buffer, format, **params)
                 data = out_buffer.getvalue()
             finally:


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-id-mobile/issues/2#issuecomment-884831078 <br> When providing an image with EXIF Orientation info, it was being ignored in the final image (after resize). |
| Decisions | - Use PIL.ImageOps method [`exif_transpose`](https://github.com/ripe-tech/ripe-id-mobile/issues/2#issuecomment-884831078) that returns an image transposed according to its EXIF orientation tag. |
| Screenshots | Original Image: <br> ![IMG_20210722_111143](https://user-images.githubusercontent.com/25725586/126669710-ce90ccb3-a542-455b-a516-a32bd9ae1fa4.jpg) <br>Before:<br>![image](https://user-images.githubusercontent.com/25725586/126669392-e97e1c98-38c6-43ac-977a-d22ccf0c1b2a.png)<br>After:<br>![image](https://user-images.githubusercontent.com/25725586/126669306-5af4bafd-a319-41a0-9e21-5694871e02a5.png) |
