### PR TITLE
fix: convert to type in 'contains' value method

### DIFF
--- a/src/appier/model.py
+++ b/src/appier/model.py
@@ -222,7 +222,7 @@ VALUE_METHODS = {
     "is_null" : lambda v, t: None,
     "not_null" : lambda v, t: None,
     "is_not_null" : lambda v, t: None,
-    "contains" : lambda v, t: [v for v in v.split(";")]
+    "contains" : lambda v, t: [t(v) for v in v.split(";")]
 }
 """ Map that associates each of the normalized operations with
 an inline function that together with the data type maps the


### PR DESCRIPTION
In a case where there is references to another model by an int identifier, it would be impossible to make a query like `filter: [field:contains:13]`, since `13` would always filter as a string.
It was missing the type convertion present in `in` and `not_in`.

This is necessary for https://github.com/ripe-tech/ripe-util-vue/issues/218 (get bulk orders of a specific order)