### PR TITLE
Fix pymongo version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix pymongo version parsing for versions without the patch number
 
 ## [1.25.0] - 2021-11-08
 

--- a/src/appier/mongo.py
+++ b/src/appier/mongo.py
@@ -282,7 +282,8 @@ def _store_ensure_index_many(store, *args, **kwargs):
 def _version_t():
     pymongo_l = _pymongo()
     if hasattr(pymongo_l, "_version_t"): return pymongo_l._version_t
-    major_s, minor_s, patch_s = pymongo.version.split(".", 2)
+    major_s, minor_s, *patch_s = pymongo.version.split(".", 2)
+    if not patch_s: patch_s = "0"
     pymongo_l._version_t = (int(major_s), int(minor_s), int(patch_s))
     return pymongo_l._version_t
 


### PR DESCRIPTION
## Issue:
Pymongo released version 4.0 on november 29 2021 and unlike the others version, this one doesn't event the patch number so as appier is assuming that pymongo will have a patch number, it fails to unpack that value and an error is thrown.
<img width="1104" alt="imagem" src="https://user-images.githubusercontent.com/22588915/144070486-dfe37514-c28b-44f8-b166-9eb62c72d18f.png">
<img width="749" alt="imagem" src="https://user-images.githubusercontent.com/22588915/144069279-a2c7cbfb-914e-4151-81af-f11a815b8aa6.png">

## Replicating the issue:
<img width="520" alt="imagem" src="https://user-images.githubusercontent.com/22588915/144069168-79ec1617-43bc-4d5b-a83e-2428e27ba940.png">

## Testing the fix:
<img width="527" alt="imagem" src="https://user-images.githubusercontent.com/22588915/144070254-0d98e750-2502-4052-814d-6f2f929f91ad.png">



