### PR TITLE
feat: graph module and priority queue Dijkstra implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* `Graph` module and dijkstra priority queue implementation
 
 ### Changed
 

--- a/src/appier/__init__.py
+++ b/src/appier/__init__.py
@@ -53,6 +53,7 @@ from . import export
 from . import extra
 from . import geo
 from . import git
+from . import graph
 from . import http
 from . import legacy
 from . import log
@@ -107,6 +108,7 @@ from .export import ExportManager
 from .extra import get_a, post_a, put_a, delete_a, patch_a, get_w, post_w, put_w, delete_w, patch_w
 from .geo import GeoResolver
 from .git import Git
+from .graph import Graph
 from .http import file_g, get_f, get, post, put, delete, HTTPResponse
 from .log import MemoryHandler, BaseFormatter, ThreadFormatter, DummyLogger, reload_format, rotating_handler,\
     smtp_handler, in_signature

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -1,3 +1,42 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Appier Framework
+# Copyright (c) 2008-2022 Hive Solutions Lda.
+#
+# This file is part of Hive Appier Framework.
+#
+# Hive Appier Framework is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Appier Framework is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Appier Framework. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__version__ = "1.0.0"
+""" The version of the module """
+
+__revision__ = "$LastChangedRevision$"
+""" The revision number of the module """
+
+__date__ = "$LastChangedDate$"
+""" The last change date of the module """
+
+__copyright__ = "Copyright (c) 2008-2021 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
 import math
 
 import appier
@@ -32,8 +71,8 @@ class Graph(object):
         for edge in edges:
             if len(edge) < 2: continue
             src, dst = edge[0], edge[1]
-            cost = edge[2] if len(edge) > 2 else 1
-            bidirectional = edge[3] if len(edge) > 3 else False
+            cost = edge[2] if len(edge) > 2 and isinstance(edge[2], int) else 1
+            bidirectional = edge[3] if len(edge) > 3 and isinstance(edge[3], bool) else False
             self.add_edge(src, dst, cost = cost, bidirectional = bidirectional)
 
     def add_edge(self, src, dst, cost = 1, bidirectional = False):

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -3,6 +3,12 @@ import math
 import appier
 
 class Graph(object):
+    """
+    Graph structure and associated algorithms. Made up by a dictionary of
+    sources to destinations and costs (weighted edges).
+    Edges are unidirectional by default.
+    Costs default to a unit.
+    """
 
     def __init__(self):
         self.edges = dict()
@@ -39,8 +45,6 @@ class Graph(object):
     def dijkstra(self, src, dst):
         """
         Dijkstra's algorithm with priority queue implementation.
-        Costs default to a unit.
-        Edges are unidirectional by default.
         """
 
         if src == dst: return [src], 0

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -31,7 +31,7 @@ __revision__ = "$LastChangedRevision$"
 __date__ = "$LastChangedDate$"
 """ The last change date of the module """
 
-__copyright__ = "Copyright (c) 2008-2021 Hive Solutions Lda."
+__copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 """ The copyright for the module """
 
 __license__ = "Apache License, Version 2.0"

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -22,6 +22,14 @@ class Graph(object):
         path.reverse()
         return path
 
+    def add_edges(self, edges):
+        for edge in edges:
+            if len(edge) < 2: continue
+            src, dst = edge[0], edge[1]
+            cost = edge[2] if len(edge) > 2 else 1
+            bidirectional = edge[3] if len(edge) > 3 else False
+            self.add_edge(src, dst, cost = cost, bidirectional = bidirectional)
+
     def add_edge(self, src, dst, cost = 1, bidirectional = False):
         if src not in self.edges: self.edges[src] = []
         self.edges[src].append((dst, cost))
@@ -35,7 +43,7 @@ class Graph(object):
         Edges are unidirectional by default.
         """
 
-        if src == dst: return [src]
+        if src == dst: return [src], 0
 
         dist, prev = dict(), dict()
         dist[src] = 0

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -92,6 +92,7 @@ class Graph(object):
 
         if src == dst: return [src], 0
 
+        cls = self.__class__
         dist, prev = dict(), dict()
         dist[src] = 0
 
@@ -112,4 +113,4 @@ class Graph(object):
                     prev[nxt] = top
                     queue.push(nxt, priority = dist[nxt])
 
-        return self._build_path(prev, src, dst), dist[dst]
+        return cls._build_path(prev, src, dst), dist[dst]

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -37,9 +37,11 @@ __copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
-import math
-
 import appier
+
+INFINITY = float("inf")
+""" Infinity value alternative to math module infinity
+compatible with Python versions 2 and 3  """
 
 class Graph(object):
     """
@@ -98,11 +100,11 @@ class Graph(object):
 
         while queue.length() > 0:
             (_, _, top) = queue.pop(full = True)
-            dist[top] = math.inf if top not in dist else dist[top]
+            dist[top] = dist[top] if top in dist else INFINITY
 
             edges = self.edges[top] if top in self.edges else []
             for (nxt, cost) in edges:
-                dist[nxt] = math.inf if nxt not in dist else dist[nxt]
+                dist[nxt] = dist[nxt] if nxt in dist else INFINITY
 
                 alt = dist[top] + cost
                 if alt < dist[nxt]:

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -22,18 +22,10 @@ class Graph(object):
         path.reverse()
         return path
 
-    def add_edges(self, edges):
-        for edge in edges:
-            if len(edge) == 2:
-                src, dst = edge
-                self.add_edge(src, dst)
-            elif len(edge) == 3:
-                src, dst, cost = edge
-                self.add_edge(src, dst, cost = cost)
-
     def add_edge(self, src, dst, cost = 1, bidirectional = False):
         if src not in self.edges: self.edges[src] = []
         self.edges[src].append((dst, cost))
+
         if bidirectional: self.add_edge(dst, src, cost = cost, bidirectional = False)
 
     def dijkstra(self, src, dst):
@@ -52,7 +44,7 @@ class Graph(object):
         queue.push(src, priority = 0)
 
         while queue.length() > 0:
-            (top_cost, _, top) = queue.pop(full = True)
+            (_, _, top) = queue.pop(full = True)
             dist[top] = math.inf if top not in dist else dist[top]
 
             edges = self.edges[top] if top in self.edges else []
@@ -63,7 +55,6 @@ class Graph(object):
                 if alt < dist[nxt]:
                     dist[nxt] = alt
                     prev[nxt] = top
+                    queue.push(nxt, priority = dist[nxt])
 
-                queue.push(nxt, priority = dist[nxt])
-
-        return self._build_path(prev, src, dst)
+        return self._build_path(prev, src, dst), dist[dst]

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -1,0 +1,69 @@
+import math
+
+import appier
+
+class Graph(object):
+
+    def __init__(self):
+        self.edges = dict()
+
+    @classmethod
+    def _build_path(cls, prev, src, dst):
+        """
+        Builds the shortest path given dictionary
+        of previous nodes.
+        """
+
+        cur, path = dst, []
+        while cur != src:
+            path.append(cur)
+            cur = prev[cur]
+        path.append(src)
+        path.reverse()
+        return path
+
+    def add_edges(self, edges):
+        for edge in edges:
+            if len(edge) == 2:
+                src, dst = edge
+                self.add_edge(src, dst)
+            elif len(edge) == 3:
+                src, dst, cost = edge
+                self.add_edge(src, dst, cost = cost)
+
+    def add_edge(self, src, dst, cost = 1, bidirectional = False):
+        if src not in self.edges: self.edges[src] = []
+        self.edges[src].append((dst, cost))
+        if bidirectional: self.add_edge(dst, src, cost = cost, bidirectional = False)
+
+    def dijkstra(self, src, dst):
+        """
+        Dijkstra's algorithm with priority queue implementation.
+        Costs default to a unit.
+        Edges are unidirectional by default.
+        """
+
+        if src == dst: return [src]
+
+        dist, prev = dict(), dict()
+        dist[src] = 0
+
+        queue = appier.MemoryQueue()
+        queue.push(src, priority = 0)
+
+        while queue.length() > 0:
+            (top_cost, _, top) = queue.pop(full = True)
+            dist[top] = math.inf if top not in dist else dist[top]
+
+            edges = self.edges[top] if top in self.edges else []
+            for (nxt, cost) in edges:
+                dist[nxt] = math.inf if nxt not in dist else dist[nxt]
+
+                alt = dist[top] + cost
+                if alt < dist[nxt]:
+                    dist[nxt] = alt
+                    prev[nxt] = top
+
+                queue.push(nxt, priority = dist[nxt])
+
+        return self._build_path(prev, src, dst)

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -49,8 +49,10 @@ class Graph(object):
     Costs default to a unit.
     """
 
-    def __init__(self):
+    def __init__(self, *args):
         self.edges = dict()
+        if len(args) > 0 and isinstance(args[0], list):
+            self.add_edges(args[0])
 
     @classmethod
     def _build_path(cls, prev, src, dst):

--- a/src/appier/structures.py
+++ b/src/appier/structures.py
@@ -38,7 +38,6 @@ __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
 import os
-import math
 
 class OrderedDict(dict):
 
@@ -275,71 +274,6 @@ class GeneratorFile(object):
 
     def close(self):
         self._generator.close()
-
-class Graph(object):
-
-    def __init__(self):
-        self.edges = dict()
-
-    def add_edges(self, edges, bidirectional = False):
-        for edge in edges:
-            if len(edge) == 2:
-                src, dst = edge
-                self.add_edge(src, dst, bidirectional = bidirectional)
-            elif len(edge) == 3:
-                src, dst, cost = edge
-                self.add_edge(src, dst, cost = cost, bidirectional = bidirectional)
-
-    def add_edge(self, src, dst, cost = 1, bidirectional = False):
-        if src not in self.edges: self.edges[src] = []
-        self.edges[src].append((dst, cost))
-        if bidirectional: self.add_edge(dst, src, cost = cost, bidirectional = False)
-
-    def dijkstra(self, src, dst):
-        """
-        Dijkstra's algorithm priority queue implementation.
-        Costs default to a unit.
-        Edges by default are unidirectional.
-        """
-
-        if src == dst: return []
-
-        dist, prev = dict(), dict()
-        dist[src] = 0
-
-        queue = MemoryQueue()
-        queue.push(src, priority = 0)
-
-        while queue.length() > 0:
-            (top_cost, _, top) = queue.pop(full = True)
-            dist[top] = math.inf if top not in dist else dist[top]
-
-            edges = self.edges[top] if top in self.edges else []
-            for (nxt, cost) in edges:
-                dist[nxt] = math.inf if nxt not in dist else dist[nxt]
-
-                alt = dist[top] + cost
-                if alt < dist[nxt]:
-                    dist[nxt] = alt
-                    prev[nxt] = top
-
-                queue.push(nxt, priority = dist[nxt])
-
-        return self._build_path(prev, src, dst)
-
-    def _build_path(self, prev, src, dst):
-        """
-        Builds the shortest path given dictionary
-        of previous nodes.
-        """
-
-        cur, path = dst, []
-        while cur != src:
-            path.append(cur)
-            cur = prev[cur]
-        path.append(src)
-        path.reverse()
-        return path
 
 lazy_dict = LazyDict
 lazy = LazyValue

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -98,47 +98,40 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(cost, 0)
 
     def test_dijkstra_simple(self):
-        graph = appier.Graph()
-        edges = [
+        graph = appier.Graph([
             ("A", "B"),
             ("B", "C")
-        ]
-        graph.add_edges(edges)
+        ])
 
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
         self.assertEqual(cost, 2)
 
     def test_dijkstra_costs(self):
-        graph = appier.Graph()
-        edges = [
+        graph = appier.Graph([
             ("A", "B"),
             ("B", "C", 10),
             ("B", "D", 4),
             ("D", "C", 5)
-        ]
-        graph.add_edges(edges)
+        ])
 
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "D", "C"])
         self.assertEqual(cost, 10)
 
     def test_dijkstra_loop(self):
-        graph = appier.Graph()
-        edges = [
+        graph = appier.Graph([
             ("A", "B"),
             ("B", "B"),
             ("B", "C")
-        ]
-        graph.add_edges(edges)
+        ])
 
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
         self.assertEqual(cost, 2)
 
     def test_dijkstra_big(self):
-        graph = appier.Graph()
-        edges = [
+        graph = appier.Graph([
             ("A", "B", 2),
             ("A", "C", 6),
             ("B", "D", 5),
@@ -148,8 +141,7 @@ class GraphTest(unittest.TestCase):
             ("E", "F", 6),
             ("E", "G", 2),
             ("F", "G", 6)
-        ]
-        graph.add_edges(edges)
+        ])
 
         path, cost = graph.dijkstra("A", "A")
         self.assertEqual(path, ["A"])

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Appier Framework
+# Copyright (c) 2008-2022 Hive Solutions Lda.
+#
+# This file is part of Hive Appier Framework.
+#
+# Hive Appier Framework is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Appier Framework is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Appier Framework. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__version__ = "1.0.0"
+""" The version of the module """
+
+__revision__ = "$LastChangedRevision$"
+""" The revision number of the module """
+
+__date__ = "$LastChangedDate$"
+""" The last change date of the module """
+
+__copyright__ = "Copyright (c) 2008-2021 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import appier
+
+class GraphTest(unittest.TestCase):
+
+    def test__build_path(self):
+        prev = dict(
+            A = "B",
+            B = "C",
+            C = "F",
+            F = "G"
+        )
+        path = appier.Graph._build_path(prev, "A", "G")
+        self.assertEqual(path, ["A", "B", "C", "F", "G"])
+
+    def test_create(self):
+        graph = appier.Graph()
+        self.assertEqual(len(graph.edges), 0)
+
+    def test_add_edges(self):
+        graph = appier.Graph()
+
+        edges = [
+            ("A", "B"),
+            ("B", "D", 20),
+            ("B", "C", 10),
+            ("D", "F"),
+            ("F", "D")
+        ]
+        graph.add_edges(edges)
+
+        self.assertEqual(graph.edges["A"], [("B", 1)])
+        self.assertEqual(graph.edges["B"], [("D", 20), ("C", 10)])
+        self.assertEqual(graph.edges["D"], [("F", 1)])
+        self.assertEqual(graph.edges["F"], [("D", 1)])
+
+    def test_add_edge(self):
+        graph = appier.Graph()
+
+        graph.add_edge("A", "B")
+        self.assertEqual(graph.edges["A"], [("B", 1)])
+
+        graph.add_edge("B", "D", cost = 20)
+        graph.add_edge("B", "C", cost = 10)
+        self.assertEqual(graph.edges["B"], [("D", 20), ("C", 10)])
+
+        graph.add_edge("D", "F", bidirectional = True)
+        self.assertEqual(graph.edges["D"], [("F", 1)])
+        self.assertEqual(graph.edges["F"], [("D", 1)])
+
+    def test_dijkstra_src_equal_dst(self):
+        graph = appier.Graph()
+        path = graph.dijkstra("A", "A")
+        self.assertEqual(path, ["A"])
+
+    def test_dijkstra_simple(self):
+        edges = [
+            ("A", "B"),
+            ("B", "C")
+        ]
+        graph = appier.Graph()
+        graph.add_edges(edges)
+        path = graph.dijkstra("A", "C")
+        self.assertEqual(path, ["A", "B", "C"])
+
+    def test_dijkstra_costs(self):
+        edges = [
+            ("A", "B"),
+            ("B", "C", 10),
+            ("B", "D", 4),
+            ("D", "C", 9)
+        ]
+        graph = appier.Graph()
+        graph.add_edges(edges)
+        path = graph.dijkstra("A", "C")
+        self.assertEqual(path, ["A", "B", "D", "C"])
+
+    def test_dijkstra_loop(self):
+        edges = [
+            ("A", "B"),
+            ("B", "B"),
+            ("B", "C")
+        ]
+        graph = appier.Graph()
+        graph.add_edges(edges)
+        path = graph.dijkstra("A", "C")
+        self.assertEqual(path, ["A", "B", "C"])
+
+    def test_dijkstra_big(self):
+        edges = [
+            ("A", "B", 2),
+            ("A", "C", 6),
+            ("B", "D", 5),
+            ("C", "D", 8),
+            ("D", "E", 10),
+            ("D", "F", 15),
+            ("E", "F", 6),
+            ("E", "G", 2),
+            ("F", "G", 6)
+        ]
+        graph = appier.Graph()
+        graph.add_edges(edges)
+
+        path = graph.dijkstra("A", "A")
+        self.assertEqual(path, ["A"])
+
+        path = graph.dijkstra("A", "B")
+        self.assertEqual(path, ["A", "B"])
+
+        path = graph.dijkstra("A", "C")
+        self.assertEqual(path, ["A", "C"])
+
+        path = graph.dijkstra("A", "D")
+        self.assertEqual(path, ["A", "B", "D"])
+
+        path = graph.dijkstra("A", "E")
+        self.assertEqual(path, ["A", "B", "D", "E"])
+
+        path = graph.dijkstra("A", "F")
+        self.assertEqual(path, ["A", "B", "D", "F"])
+
+        path = graph.dijkstra("A", "G")
+        self.assertEqual(path, ["A", "B", "D", "E", "G"])
+
+        path = graph.dijkstra("C", "G")
+        self.assertEqual(path, ["C", "D", "E", "G"])
+
+        path = graph.dijkstra("C", "F")
+        self.assertEqual(path, ["C", "D", "F"])

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -45,17 +45,36 @@ class GraphTest(unittest.TestCase):
 
     def test__build_path(self):
         prev = dict(
-            A = "B",
-            B = "C",
-            C = "F",
-            F = "G"
+            B = "A",
+            C = "A",
+            D = "B",
+            E = "D",
+            F = "D",
+            G = "E"
         )
-        path = appier.Graph._build_path(prev, "A", "G")
-        self.assertEqual(path, ["A", "B", "C", "F", "G"])
+        path = appier.Graph._build_path(prev, "A", "F")
+        self.assertEqual(path, ["A", "B", "D", "F"])
 
     def test_create(self):
         graph = appier.Graph()
         self.assertEqual(len(graph.edges), 0)
+
+    def test_add_edges(self):
+        graph = appier.Graph()
+
+        edges = [
+            ("A", "B"),
+            ("B", "D", 20),
+            ("B", "C", 10, True),
+            ("D", "F"),
+            ("F", "D")
+        ]
+        graph.add_edges(edges)
+
+        self.assertEqual(graph.edges["A"], [("B", 1)])
+        self.assertEqual(graph.edges["B"], [("D", 20), ("C", 10)])
+        self.assertEqual(graph.edges["D"], [("F", 1)])
+        self.assertEqual(graph.edges["F"], [("D", 1)])
 
     def test_add_edge(self):
         graph = appier.Graph()
@@ -73,8 +92,9 @@ class GraphTest(unittest.TestCase):
 
     def test_dijkstra_src_equal_dst(self):
         graph = appier.Graph()
-        path = graph.dijkstra("A", "A")
+        path, cost = graph.dijkstra("A", "A")
         self.assertEqual(path, ["A"])
+        self.assertEqual(cost, 0)
 
     def test_dijkstra_simple(self):
         edges = [
@@ -83,20 +103,22 @@ class GraphTest(unittest.TestCase):
         ]
         graph = appier.Graph()
         graph.add_edges(edges)
-        path = graph.dijkstra("A", "C")
+        path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
+        self.assertEqual(cost, 2)
 
     def test_dijkstra_costs(self):
         edges = [
             ("A", "B"),
             ("B", "C", 10),
             ("B", "D", 4),
-            ("D", "C", 9)
+            ("D", "C", 5)
         ]
         graph = appier.Graph()
         graph.add_edges(edges)
-        path = graph.dijkstra("A", "C")
+        path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "D", "C"])
+        self.assertEqual(cost, 10)
 
     def test_dijkstra_loop(self):
         edges = [
@@ -106,8 +128,9 @@ class GraphTest(unittest.TestCase):
         ]
         graph = appier.Graph()
         graph.add_edges(edges)
-        path = graph.dijkstra("A", "C")
+        path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
+        self.assertEqual(cost, 2)
 
     def test_dijkstra_big(self):
         edges = [
@@ -124,29 +147,38 @@ class GraphTest(unittest.TestCase):
         graph = appier.Graph()
         graph.add_edges(edges)
 
-        path = graph.dijkstra("A", "A")
+        path, cost = graph.dijkstra("A", "A")
         self.assertEqual(path, ["A"])
+        self.assertEqual(cost, 0)
 
-        path = graph.dijkstra("A", "B")
+        path, cost = graph.dijkstra("A", "B")
         self.assertEqual(path, ["A", "B"])
+        self.assertEqual(cost, 2)
 
-        path = graph.dijkstra("A", "C")
+        path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "C"])
+        self.assertEqual(cost, 6)
 
-        path = graph.dijkstra("A", "D")
+        path, cost = graph.dijkstra("A", "D")
         self.assertEqual(path, ["A", "B", "D"])
+        self.assertEqual(cost, 7)
 
-        path = graph.dijkstra("A", "E")
+        path, cost = graph.dijkstra("A", "E")
         self.assertEqual(path, ["A", "B", "D", "E"])
+        self.assertEqual(cost, 17)
 
-        path = graph.dijkstra("A", "F")
+        path, cost = graph.dijkstra("A", "F")
         self.assertEqual(path, ["A", "B", "D", "F"])
+        self.assertEqual(cost, 22)
 
-        path = graph.dijkstra("A", "G")
+        path, cost = graph.dijkstra("A", "G")
         self.assertEqual(path, ["A", "B", "D", "E", "G"])
+        self.assertEqual(cost, 19)
 
-        path = graph.dijkstra("C", "G")
+        path, cost = graph.dijkstra("C", "G")
         self.assertEqual(path, ["C", "D", "E", "G"])
+        self.assertEqual(cost, 20)
 
-        path = graph.dijkstra("C", "F")
+        path, cost = graph.dijkstra("C", "F")
         self.assertEqual(path, ["C", "D", "F"])
+        self.assertEqual(cost, 23)

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -31,7 +31,7 @@ __revision__ = "$LastChangedRevision$"
 __date__ = "$LastChangedDate$"
 """ The last change date of the module """
 
-__copyright__ = "Copyright (c) 2008-2021 Hive Solutions Lda."
+__copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 """ The copyright for the module """
 
 __license__ = "Apache License, Version 2.0"

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -60,6 +60,13 @@ class GraphTest(unittest.TestCase):
         graph = appier.Graph()
         self.assertEqual(len(graph.edges), 0)
 
+    def test_create_with_argument(self):
+        graph = appier.Graph([
+            ("A", "B"),
+            ("B", "D", 20, True)
+        ])
+        self.assertEqual(len(graph.edges), 3)
+
     def test_add_edges(self):
         graph = appier.Graph()
         edges = [
@@ -68,6 +75,24 @@ class GraphTest(unittest.TestCase):
             ("B", "C", 10, True),
             ("D", "F"),
             ("F", "D")
+        ]
+        graph.add_edges(edges)
+
+        self.assertEqual(graph.edges["A"], [("B", 1)])
+        self.assertEqual(graph.edges["B"], [("D", 20), ("C", 10)])
+        self.assertEqual(graph.edges["D"], [("F", 1)])
+        self.assertEqual(graph.edges["F"], [("D", 1)])
+
+    def test_add_edges_handle_invalid(self):
+        graph = appier.Graph()
+        edges = [
+            ("A", "B", "invalid", "invalid"),
+            ("B", "D", 20),
+            ("B", "C", 10, True),
+            ("D", "F"),
+            ("F", "D"),
+            (),
+            ("A")
         ]
         graph.add_edges(edges)
 

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -52,6 +52,7 @@ class GraphTest(unittest.TestCase):
             F = "D",
             G = "E"
         )
+
         path = appier.Graph._build_path(prev, "A", "F")
         self.assertEqual(path, ["A", "B", "D", "F"])
 
@@ -61,7 +62,6 @@ class GraphTest(unittest.TestCase):
 
     def test_add_edges(self):
         graph = appier.Graph()
-
         edges = [
             ("A", "B"),
             ("B", "D", 20),
@@ -92,47 +92,52 @@ class GraphTest(unittest.TestCase):
 
     def test_dijkstra_src_equal_dst(self):
         graph = appier.Graph()
+
         path, cost = graph.dijkstra("A", "A")
         self.assertEqual(path, ["A"])
         self.assertEqual(cost, 0)
 
     def test_dijkstra_simple(self):
+        graph = appier.Graph()
         edges = [
             ("A", "B"),
             ("B", "C")
         ]
-        graph = appier.Graph()
         graph.add_edges(edges)
+
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
         self.assertEqual(cost, 2)
 
     def test_dijkstra_costs(self):
+        graph = appier.Graph()
         edges = [
             ("A", "B"),
             ("B", "C", 10),
             ("B", "D", 4),
             ("D", "C", 5)
         ]
-        graph = appier.Graph()
         graph.add_edges(edges)
+
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "D", "C"])
         self.assertEqual(cost, 10)
 
     def test_dijkstra_loop(self):
+        graph = appier.Graph()
         edges = [
             ("A", "B"),
             ("B", "B"),
             ("B", "C")
         ]
-        graph = appier.Graph()
         graph.add_edges(edges)
+
         path, cost = graph.dijkstra("A", "C")
         self.assertEqual(path, ["A", "B", "C"])
         self.assertEqual(cost, 2)
 
     def test_dijkstra_big(self):
+        graph = appier.Graph()
         edges = [
             ("A", "B", 2),
             ("A", "C", 6),
@@ -144,7 +149,6 @@ class GraphTest(unittest.TestCase):
             ("E", "G", 2),
             ("F", "G", 6)
         ]
-        graph = appier.Graph()
         graph.add_edges(edges)
 
         path, cost = graph.dijkstra("A", "A")

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -57,23 +57,6 @@ class GraphTest(unittest.TestCase):
         graph = appier.Graph()
         self.assertEqual(len(graph.edges), 0)
 
-    def test_add_edges(self):
-        graph = appier.Graph()
-
-        edges = [
-            ("A", "B"),
-            ("B", "D", 20),
-            ("B", "C", 10),
-            ("D", "F"),
-            ("F", "D")
-        ]
-        graph.add_edges(edges)
-
-        self.assertEqual(graph.edges["A"], [("B", 1)])
-        self.assertEqual(graph.edges["B"], [("D", 20), ("C", 10)])
-        self.assertEqual(graph.edges["D"], [("F", 1)])
-        self.assertEqual(graph.edges["F"], [("D", 1)])
-
     def test_add_edge(self):
         graph = appier.Graph()
 


### PR DESCRIPTION
This relates to the RIPE Tech issue of [multiple state transitions](https://github.com/ripe-tech/ripe-core/issues/4659).

For RIPE Tech, we will need to find the shortest path between two states and make all the in-between transitions.
Instead of a bespoke solution for order states only, I thought it was better to generalize the issue at hand: finding the shortest path in the graph. Hence I decided to implement a simple Dijkstra. This will allow us to abstract that logic here and simply apply the transitions in RIPE Core. It will also work for future entities with their own states and state graphs (while a bespoke solution for Order statuses only would not).

I think this source makes sense to be added to the Appier codebase because a graph module and graph utilities by themselves are useful in many domains (maybe in the future in networking to find the shortest path between nodes).

The proposed and implemented API is:

```python
import appier

# a list of edges which is a list of tuples
# where the first element is the source node
# the second element is the destination node
# the third element is the cost of the edge (defaults to 1)
# the fourth element indicates whether the edge is bidirectional or not (defaults to unidirectional)
edges = [
    ("A", "B"),
    ("A", "C", 6, True),
    ("B", "D"),
    ("C", "D"),
    ("D", "E", 10),
    ("D", "F", 15),
    ("E", "F", 6),
    ("E", "G", 2),
    ("F", "G", 6)
]
graph = appier.Graph()
graph.add_edges(edges)

path, cost = graph.dijkstra("A", "F")
assert(path == ['A', 'B', 'D', 'F'])
assert(cost == 17)
```

Initializing the graph can also be done by passing the edges as an argument:

```python
graph = appier.Graph([
    ("A", "B"),
    ("A", "C", 6, True),
    ("B", "D"),
    ("C", "D"),
    ("D", "E", 10),
    ("D", "F", 15),
    ("E", "F", 6),
    ("E", "G", 2),
    ("F", "G", 6)
])
```

