### PR TITLE
fix: Dijkstra's implementation for no path found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Graph's Dijkstra in case of no available path
 
 ## [1.26.0] - 2022-02-23
 

--- a/src/appier/defines.py
+++ b/src/appier/defines.py
@@ -39,6 +39,10 @@ __license__ = "Apache License, Version 2.0"
 
 import re
 
+INFINITY = float("inf")
+""" Infinity value alternative to math module infinity
+compatible with Python versions 2 and 3  """
+
 ITERABLES = (list, tuple)
 """ The tuple that defined the various base types
 that are considered to be generally "iterable" """

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -37,11 +37,8 @@ __copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
-import appier
-
-INFINITY = float("inf")
-""" Infinity value alternative to math module infinity
-compatible with Python versions 2 and 3  """
+from .defines import INFINITY
+from .queuing import MemoryQueue
 
 class Graph(object):
     """
@@ -105,7 +102,7 @@ class Graph(object):
         dist, prev = dict(), dict()
         dist[src] = 0
 
-        queue = appier.MemoryQueue()
+        queue = MemoryQueue()
         queue.push(src, priority = 0)
 
         while queue.length() > 0:
@@ -122,4 +119,6 @@ class Graph(object):
                     prev[nxt] = top
                     queue.push(nxt, priority = dist[nxt])
 
-        return cls._build_path(prev, src, dst), dist[dst] if dst in dist else 0
+        path = cls._build_path(prev, src, dst)
+        cost = dist[dst] if dst in dist else INFINITY
+        return path, cost

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -66,6 +66,7 @@ class Graph(object):
         cur, path = dst, []
         while not cur == src:
             path.append(cur)
+            if not cur in prev: return []
             cur = prev[cur]
         path.append(src)
         path.reverse()
@@ -121,4 +122,4 @@ class Graph(object):
                     prev[nxt] = top
                     queue.push(nxt, priority = dist[nxt])
 
-        return cls._build_path(prev, src, dst), dist[dst]
+        return cls._build_path(prev, src, dst), dist[dst] if dst in dist else 0

--- a/src/appier/graph.py
+++ b/src/appier/graph.py
@@ -37,8 +37,8 @@ __copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
-from .defines import INFINITY
-from .queuing import MemoryQueue
+from . import defines
+from . import queuing
 
 class Graph(object):
     """
@@ -102,16 +102,16 @@ class Graph(object):
         dist, prev = dict(), dict()
         dist[src] = 0
 
-        queue = MemoryQueue()
+        queue = queuing.MemoryQueue()
         queue.push(src, priority = 0)
 
         while queue.length() > 0:
             (_, _, top) = queue.pop(full = True)
-            dist[top] = dist[top] if top in dist else INFINITY
+            dist[top] = dist[top] if top in dist else defines.INFINITY
 
             edges = self.edges[top] if top in self.edges else []
             for (nxt, cost) in edges:
-                dist[nxt] = dist[nxt] if nxt in dist else INFINITY
+                dist[nxt] = dist[nxt] if nxt in dist else defines.INFINITY
 
                 alt = dist[top] + cost
                 if alt < dist[nxt]:
@@ -120,5 +120,5 @@ class Graph(object):
                     queue.push(nxt, priority = dist[nxt])
 
         path = cls._build_path(prev, src, dst)
-        cost = dist[dst] if dst in dist else INFINITY
+        cost = dist[dst] if dst in dist else defines.INFINITY
         return path, cost

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -115,6 +115,25 @@ class GraphTest(unittest.TestCase):
         self.assertEqual(graph.edges["D"], [("F", 1)])
         self.assertEqual(graph.edges["F"], [("D", 1)])
 
+    def test_disjktra_no_path(self):
+        graph = appier.Graph([
+            ("A", "B"),
+            ("B", "C"),
+            ("F", "G")
+        ])
+
+        path, cost = graph.dijkstra("C", "A")
+        self.assertEqual(path, [])
+        self.assertEqual(cost, 0)
+
+        path, cost = graph.dijkstra("C", "B")
+        self.assertEqual(path, [])
+        self.assertEqual(cost, 0)
+
+        path, cost = graph.dijkstra("A", "F")
+        self.assertEqual(path, [])
+        self.assertEqual(cost, 0)
+
     def test_dijkstra_src_equal_dst(self):
         graph = appier.Graph()
 

--- a/src/appier/test/graph.py
+++ b/src/appier/test/graph.py
@@ -124,15 +124,15 @@ class GraphTest(unittest.TestCase):
 
         path, cost = graph.dijkstra("C", "A")
         self.assertEqual(path, [])
-        self.assertEqual(cost, 0)
+        self.assertEqual(cost, appier.defines.INFINITY)
 
         path, cost = graph.dijkstra("C", "B")
         self.assertEqual(path, [])
-        self.assertEqual(cost, 0)
+        self.assertEqual(cost, appier.defines.INFINITY)
 
         path, cost = graph.dijkstra("A", "F")
         self.assertEqual(path, [])
-        self.assertEqual(cost, 0)
+        self.assertEqual(cost, appier.defines.INFINITY)
 
     def test_dijkstra_src_equal_dst(self):
         graph = appier.Graph()


### PR DESCRIPTION
Previous implementation threw a `KeyError`.

This PR adds a unit test covering the no path case and changes it to return no path and infinity for the cost (`[]`, `INFINITY`).

It also places `INFINITY` in a common place (`defines.py`) to be used both by tests and graph module code.