### PR TITLE
feat: converts the filters passed before executing the `count` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Graph's Dijkstra in case of no available path
+* Converts the filters passed before executing the `count` operation
 
 ## [1.26.0] - 2022-02-23
 

--- a/src/appier/model.py
+++ b/src/appier/model.py
@@ -609,6 +609,10 @@ class Model(legacy.with_meta(meta.Ordered, observer.Observable, *EXTRA_CLS)):
     @classmethod
     def count(cls, *args, **kwargs):
         cls._clean_attrs(kwargs)
+
+        cls._find_s(kwargs)
+        cls._find_d(kwargs)
+
         collection = cls._collection()
         if kwargs:
             if hasattr(collection, "count_documents"):

--- a/src/appier/test/model.py
+++ b/src/appier/test/model.py
@@ -109,6 +109,12 @@ class ModelTest(unittest.TestCase):
         result = mock.Person.count()
         self.assertEqual(result, 1)
 
+        result = mock.Person.count(**{ 'find_d': ['name:eq:Name'] })
+        self.assertEqual(result, 1)
+
+        result = mock.Person.count(**{ 'find_d': ['name:eq:OtherName'] })
+        self.assertEqual(result, 0)
+
     def test_delete(self):
         result = mock.Person.count()
         self.assertEqual(result, 0)

--- a/src/appier/test/model.py
+++ b/src/appier/test/model.py
@@ -109,6 +109,11 @@ class ModelTest(unittest.TestCase):
         result = mock.Person.count()
         self.assertEqual(result, 1)
 
+        adapter = appier.get_adapter()
+        if adapter.name == "tiny":
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("Adapter tiny is not supported")
+
         result = mock.Person.count(**{ 'find_d': ['name:eq:Name'] })
         self.assertEqual(result, 1)
 


### PR DESCRIPTION
Support for parsing and converting the `kwargs` of `count` function, similar to the logic present in `find`. 
This is required if we want to use the same filtering logic for counting as the one we have for listing.