### PR TITLE
fix: release the id increment lock after generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Identifier generation (`DataAdapter._id`) no longer leaks the increment lock, which deadlocked inserts from background threads (e.g. scheduler jobs over the tiny adapter) - [#86](https://github.com/hivesolutions/appier/issues/86)
 
 ## [1.46.0] - 2026-05-31
 

--- a/src/appier/data.py
+++ b/src/appier/data.py
@@ -105,7 +105,7 @@ class DataAdapter(object):
         try:
             token += struct.pack(">i", self._inc)[1:4]
             self._inc = (self._inc + 1) % 0xFFFFFF
-        except Exception:
+        finally:
             self._inc_lock.release()
         token_s = binascii.hexlify(token)
         token_s = legacy.str(token_s)

--- a/src/appier/test/data.py
+++ b/src/appier/test/data.py
@@ -30,6 +30,7 @@ __license__ = "Apache License, Version 2.0"
 
 import os
 import tempfile
+import threading
 import unittest
 
 import appier
@@ -42,6 +43,24 @@ class DataTest(unittest.TestCase):
 
         self.assertEqual(type(identifier), str)
         self.assertEqual(len(identifier), 24)
+
+    def test_id_lock_release(self):
+        adapter = appier.DataAdapter()
+        adapter._id()
+
+        result = []
+
+        def acquire():
+            acquired = adapter._inc_lock.acquire(False)
+            if acquired:
+                adapter._inc_lock.release()
+            result.append(acquired)
+
+        thread = threading.Thread(target=acquire)
+        thread.start()
+        thread.join()
+
+        self.assertEqual(result, [True])
 
     def test_drop_db_missing(self):
         fd, file_path = tempfile.mkstemp()


### PR DESCRIPTION
`DataAdapter._id` acquired `_inc_lock` (an `RLock`) and released it only on the exception path, leaking the acquisition on every successful call. The owning thread (whichever performs the first insert, typically the main thread at boot) keeps re-entering its own `RLock`, so single-threaded usage never notices - but any other thread blocks forever on its first insert through an adapter that generates identifiers via `_id` (e.g. `TinyAdapter`). In practice, appier `Scheduler`-driven jobs writing over the tiny adapter deadlock silently: the tick never completes and nothing is logged.

The lock is now released in a `finally` clause. The new `test_id_lock_release` regression test asserts the lock is acquirable from another thread after `_id` runs - it fails on the previous code and passes now. The Mongo path was never affected (identifier generation is delegated to pymongo).

Found while wiring fidelia's scheduler bots (hivesolutions/fidelia#5), whose thread hung on the first `Voucher.save()`.

Closes #86
